### PR TITLE
fix typecheck on build and cluster typing

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,12 +9,6 @@ const config = {
             },
         ];
     },
-    typescript: {
-        ignoreBuildErrors: true,
-    },
-    eslint: {
-        ignoreDuringBuilds: true,
-    },
 };
 
 export default config;

--- a/src/components/common/token-balance-delta.tsx
+++ b/src/components/common/token-balance-delta.tsx
@@ -1,4 +1,3 @@
-import noLogoImg from "@/../public/assets/noLogoImg.svg";
 import cloudflareLoader from "@/utils/imageLoader";
 import { PublicKey } from "@solana/web3.js";
 import { BigNumber } from "bignumber.js";
@@ -6,6 +5,8 @@ import Image from "next/image";
 import React from "react";
 
 import { useGetTokenListVerified } from "@/hooks/jupiterTokenList";
+
+const NO_LOGO_SRC = "/assets/noLogoImg.svg";
 
 export function TokenBalanceDelta({
   mint,
@@ -37,7 +38,7 @@ export function TokenBalanceDelta({
             loading="eager"
             onError={(event: any) => {
               event.target.id = "noLogoImg";
-              event.target.srcset = noLogoImg.src;
+              event.target.srcset = NO_LOGO_SRC;
             }}
             className="h-6 w-6 rounded-full"
           />

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -1,4 +1,6 @@
-import { Cluster, PublicKey } from "@solana/web3.js";
+import { PublicKey } from "@solana/web3.js";
+
+import type { Cluster } from "./cluster";
 import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 


### PR DESCRIPTION
hey, noticed `next.config` was set to ignore typescript and eslint during production builds, which means broken code could ship as long as webpack compiled. pulled those flags so `next build` actually runs the same checks you get in dev.

also `programLabel` imported `Cluster` from web3.js but the program map and call sites use the app cluster enum from `utils/cluster`, so the types were incompatible and the explorer was in this weird split brain state. swapped the import to match.

last thing, the token delta component imported an svg through a path typescript could not resolve on a clean checkout. using the public url for the placeholder logo avoids that and still works with the error fallback.